### PR TITLE
Update 7.3 Atomic-tutorial.md

### DIFF
--- a/zh/chapter7-Atomic/7.3 Atomic-tutorial.md
+++ b/zh/chapter7-Atomic/7.3 Atomic-tutorial.md
@@ -224,9 +224,9 @@ C++11 标准中的基本 `std::atomic` 模板定义如下：
      
     int main ()
     {
-        std::vector<std::thread> threa    ds;
+        std::vector<std::thread> threads;
         std::cout << "spawning 10 threads that count to 1 million...\n";
-        for (int i=1; i<=10; ++i) threads.push_back(std::thread(count1m,i));
+        for (int i=1; i<=10; ++i) threads.push_back(std::thread(do_count1m,i));
         ready = true;
      
         for (auto& th : threads) th.join();
@@ -259,7 +259,7 @@ atomic&amp; operator= (const atomic&amp;) volatile = delete;</pre>
     #include <atomic>               // std::atomic
     #include <thread>               // std::thread, std::this_thread::yield
      
-    std::atomic <int> foo = 0;
+    std::atomic <int> foo(0);
      
     void set_foo(int x)
     {
@@ -418,8 +418,8 @@ atomic&amp; operator= (const atomic&amp;) volatile = delete;</pre>
     #include <atomic>         // std::atomic
     #include <thread>         // std::thread, std::this_thread::yield
      
-    std::atomic<int> foo = 0;
-    std::atomic<int> bar = 0;
+    std::atomic<int> foo(0);
+    std::atomic<int> bar(0);
      
     void set_foo(int x)
     {


### PR DESCRIPTION
### 修改小bug
- 其中有几个例子中，原子类型使用=赋值初始化，而此方法已经被删除。
- 有一个例程存在编辑错误
